### PR TITLE
Fix the initial test.py in StorageQueue

### DIFF
--- a/cloudmesh/storage/StorageABC.py
+++ b/cloudmesh/storage/StorageABC.py
@@ -15,6 +15,7 @@ class StorageABC(metaclass=ABCMeta):
             self.kind = spec[service]['cm']['kind']
             self.cloud = service
             self.service = service
+            self.default = spec[service]['default']
         except Exception as e:
             raise ValueError(f"storage service {service} not specified")
             print(e)

--- a/cloudmesh/storage/StorageNewABC.py
+++ b/cloudmesh/storage/StorageNewABC.py
@@ -15,6 +15,7 @@ class StorageABC(metaclass=ABCMeta):
             self.kind = self.config[f"cloudmesh.storage.{service}.cm.kind"]
             self.cloud = service
             self.service = service
+            self.default = spec[service]["default"]
         except Exception as e:
             raise ValueError(f"storage service {service} not specified")
             print(e)

--- a/cloudmesh/storage/provider/local/Provider.py
+++ b/cloudmesh/storage/provider/local/Provider.py
@@ -58,8 +58,13 @@ class Provider(StorageABC):
     def __init__(self, service=None, config="~/.cloudmesh/cloudmesh.yaml"):
         super(Provider, self).__init__(service=service, config=config)
 
-        self.credentials["directory"] = path_expand(
-            self.credentials["directory"])
+        if "directory" in self.credentials.keys():
+            self.credentials["directory"] = path_expand(
+                self.credentials["directory"])
+        else:
+            self.credentials["directory"] = path_expand(
+                self.default["directory"]
+            )
 
     def _filename(self, filename):
         return Path(self.credentials["directory"]) / filename
@@ -306,3 +311,9 @@ class Provider(StorageABC):
         source = self._dirname(directory)
         r = Shell.execute(f"tree {source}")
         print(r)
+
+
+
+if __name__ == "__main__":
+    p = Provider(service="storage_a")
+    print()

--- a/cloudmesh/storage/queue/StorageQueue.py
+++ b/cloudmesh/storage/queue/StorageQueue.py
@@ -96,9 +96,13 @@ class StorageQueue:
         #
         # TODO: create collection in mongodb
         #
+        # Create collection in mongodb via CmDatabase
+        cm = CmDatabase()
+        if self.collection not in cm.collections():
+            cm.command({"create":self.collection})
         Console.ok(f"Collection: {self.name}")
 
-    def _copy_file(self, sourcefile, destinationfile):
+    def _copy_file(self, sourcefile, destinationfile=None):
         """
         adds a copy action to the queue
 
@@ -114,6 +118,11 @@ class StorageQueue:
         """
         date = DateTime.now()
         uuid_str = str(uuid.uuid1())
+
+        # If remove is not specified, source path is used for it.
+        if destinationfile == None or destinationfile == "":
+            destinationfile = sourcefile
+
         specification = textwrap.dedent(f"""
         cm:
            number: {self.number}
@@ -133,6 +142,9 @@ class StorageQueue:
         status: waiting
         """)
         entries = yaml.load(specification, Loader=yaml.SafeLoader)
+        cm = CmDatabase()
+        cm.insert(entries, self.collection)
+
         self.number = self.number + 1
         return entries
 


### PR DESCRIPTION
The initial test.py for StorageQueue was failing because the storage_a and storage_b's credentials don't have the "directory" key. I modify the StorageABC.py and StorageNewABC.py to handle this case by use the "default" directory if "directory" doesn't exist under "credentials".